### PR TITLE
Update comparison notebook to use an RMM pool

### DIFF
--- a/Comparing_Frameworks.ipynb
+++ b/Comparing_Frameworks.ipynb
@@ -36,7 +36,7 @@
     "    process_previous_applications, installments_payments,\n",
     "    credit_card_balance\n",
     "    )\n",
-    "import cudf as dd\n",
+    "import cudf as xd\n",
     "import gc\n",
     "import numpy as np\n",
     "import pandas as pd"
@@ -45,12 +45,11 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "level-hartford",
+   "id": "d27d4faf-f5a1-490b-bfc9-4f62504af911",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# this allows for overflow of gpu ram to normal ram and hence avoid Out of Memory Errors\n",
-    "dd.set_allocator(\"managed\")"
+    "xd.set_allocator(pool=True, initial_pool_size=14e9) # roughly 14GB pool"
    ]
   },
   {
@@ -74,14 +73,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 1.86 s, sys: 366 ms, total: 2.22 s\n",
-      "Wall time: 2.23 s\n"
+      "CPU times: user 794 ms, sys: 268 ms, total: 1.06 s\n",
+      "Wall time: 1.06 s\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "0"
+       "19"
       ]
      },
      "execution_count": 4,
@@ -91,20 +90,20 @@
    ],
    "source": [
     "%%time\n",
-    "bureau_balance = dd.read_parquet('raw_data/bureau_balance.parquet')\n",
-    "bureau = dd.read_parquet('raw_data/bureau.parquet')\n",
-    "cc_balance = dd.read_parquet('raw_data/cc_balance.parquet')\n",
-    "payments = dd.read_parquet('raw_data/payments.parquet')\n",
-    "pc_balance = dd.read_parquet('raw_data/pc_balance.parquet')\n",
-    "prev = dd.read_parquet('raw_data/prev.parquet')\n",
-    "train = dd.read_parquet('raw_data/train.parquet')\n",
-    "test = dd.read_parquet('raw_data/test.parquet')\n",
+    "bureau_balance = xd.read_parquet('raw_data/bureau_balance.parquet')\n",
+    "bureau = xd.read_parquet('raw_data/bureau.parquet')\n",
+    "cc_balance = xd.read_parquet('raw_data/cc_balance.parquet')\n",
+    "payments = xd.read_parquet('raw_data/payments.parquet')\n",
+    "pc_balance = xd.read_parquet('raw_data/pc_balance.parquet')\n",
+    "prev = xd.read_parquet('raw_data/prev.parquet')\n",
+    "train = xd.read_parquet('raw_data/train.parquet')\n",
+    "test = xd.read_parquet('raw_data/test.parquet')\n",
     "\n",
     "train_index = train.index\n",
     "test_index = test.index\n",
     "\n",
     "train_target = train['TARGET']\n",
-    "unified = dd.concat([train.drop('TARGET', axis=1), test])\n",
+    "unified = xd.concat([train.drop('TARGET', axis=1), test])\n",
     "\n",
     "del(train)\n",
     "del(test)\n",
@@ -113,7 +112,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 5,
    "id": "typical-offer",
    "metadata": {},
    "outputs": [
@@ -121,28 +120,35 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 15.1 s, sys: 2.48 s, total: 17.6 s\n",
-      "Wall time: 17.6 s\n"
+      "CPU times: user 4.21 s, sys: 779 ms, total: 4.98 s\n",
+      "Wall time: 5.05 s\n"
      ]
     }
    ],
    "source": [
     "%%time\n",
     "\n",
-    "unified_feat = process_unified(unified, dd)\n",
+    "unified_feat = process_unified(unified, xd)\n",
     "\n",
-    "bureau_agg = process_bureau_and_balance(bureau, bureau_balance, dd)\n",
+    "bureau_agg = process_bureau_and_balance(bureau, bureau_balance, xd)\n",
+    "del unified, bureau, bureau_balance\n",
     "\n",
-    "prev_agg = process_previous_applications(prev, dd)\n",
-    "pos_agg = pos_cash(pc_balance, dd)\n",
-    "ins_agg = installments_payments(payments, dd)\n",
-    "cc_agg = credit_card_balance(cc_balance, dd)\n",
+    "prev_agg = process_previous_applications(prev, xd)\n",
+    "pos_agg = pos_cash(pc_balance, xd)\n",
+    "ins_agg = installments_payments(payments, xd)\n",
+    "cc_agg = credit_card_balance(cc_balance, xd)\n",
+    "\n",
+    "del prev, pc_balance, payments, cc_balance\n",
+    "gc.collect()\n",
     "\n",
     "unified_feat = unified_feat.join(bureau_agg, how='left', on='SK_ID_CURR') \\\n",
     "    .join(prev_agg, how='left', on='SK_ID_CURR') \\\n",
     "    .join(pos_agg, how='left', on='SK_ID_CURR') \\\n",
     "    .join(ins_agg, how='left', on='SK_ID_CURR') \\\n",
     "    .join(cc_agg, how='left', on='SK_ID_CURR')\n",
+    "\n",
+    "del bureau_agg, prev_agg, pos_agg, ins_agg, cc_agg\n",
+    "gc.collect()\n",
     "\n",
     "# we can't use bool column types in xgb later on\n",
     "bool_columns = [col for col in unified_feat.columns if (unified_feat[col].dtype in ['bool']) ]    \n",
@@ -179,7 +185,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 6,
    "id": "certain-miami",
    "metadata": {},
    "outputs": [
@@ -187,14 +193,16 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 4.16 s, sys: 404 ms, total: 4.56 s\n",
-      "Wall time: 4.73 s\n"
+      "CPU times: user 748 ms, sys: 292 ms, total: 1.04 s\n",
+      "Wall time: 1.04 s\n"
      ]
     }
    ],
    "source": [
     "%%time\n",
     "train_feats.to_parquet('data_eng/feats/train_feats.parquet')\n",
+    "del train_feats\n",
+    "\n",
     "test_feats.to_parquet('data_eng/feats/test_feats.parquet')"
    ]
   },
@@ -208,19 +216,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 7,
    "id": "central-corrections",
    "metadata": {},
    "outputs": [],
    "source": [
     "from feature_engineering_2 import process_unified, process_bureau_and_balance\n",
-    "import pandas as dd\n",
+    "import pandas as xd\n",
     "import gc"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 8,
    "id": "grave-lunch",
    "metadata": {},
    "outputs": [
@@ -228,8 +236,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 7.03 s, sys: 4.39 s, total: 11.4 s\n",
-      "Wall time: 5.4 s\n"
+      "CPU times: user 6.25 s, sys: 4.63 s, total: 10.9 s\n",
+      "Wall time: 7.57 s\n"
      ]
     },
     {
@@ -238,27 +246,27 @@
        "0"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "%%time\n",
-    "bureau_balance = dd.read_parquet('raw_data/bureau_balance.parquet')\n",
-    "bureau = dd.read_parquet('raw_data/bureau.parquet')\n",
-    "cc_balance = dd.read_parquet('raw_data/cc_balance.parquet')\n",
-    "payments = dd.read_parquet('raw_data/payments.parquet')\n",
-    "pc_balance = dd.read_parquet('raw_data/pc_balance.parquet')\n",
-    "prev = dd.read_parquet('raw_data/prev.parquet')\n",
-    "train = dd.read_parquet('raw_data/train.parquet')\n",
-    "test = dd.read_parquet('raw_data/test.parquet')\n",
+    "bureau_balance = xd.read_parquet('raw_data/bureau_balance.parquet')\n",
+    "bureau = xd.read_parquet('raw_data/bureau.parquet')\n",
+    "cc_balance = xd.read_parquet('raw_data/cc_balance.parquet')\n",
+    "payments = xd.read_parquet('raw_data/payments.parquet')\n",
+    "pc_balance = xd.read_parquet('raw_data/pc_balance.parquet')\n",
+    "prev = xd.read_parquet('raw_data/prev.parquet')\n",
+    "train = xd.read_parquet('raw_data/train.parquet')\n",
+    "test = xd.read_parquet('raw_data/test.parquet')\n",
     "\n",
     "train_index = train.index\n",
     "test_index = test.index\n",
     "\n",
     "train_target = train['TARGET']\n",
-    "unified = dd.concat([train.drop('TARGET', axis=1), test])\n",
+    "unified = xd.concat([train.drop('TARGET', axis=1), test])\n",
     "\n",
     "del(train)\n",
     "del(test)\n",
@@ -267,7 +275,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 9,
    "id": "precious-pepper",
    "metadata": {},
    "outputs": [],
@@ -282,7 +290,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 10,
    "id": "experimental-adams",
    "metadata": {},
    "outputs": [
@@ -290,22 +298,22 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 36.1 s, sys: 2 s, total: 38.1 s\n",
-      "Wall time: 38.1 s\n"
+      "CPU times: user 47.8 s, sys: 9.15 s, total: 56.9 s\n",
+      "Wall time: 56.9 s\n"
      ]
     }
    ],
    "source": [
     "%%time\n",
     "\n",
-    "unified_feat = process_unified(unified, dd)\n",
+    "unified_feat = process_unified(unified, xd)\n",
     "\n",
-    "bureau_agg = process_bureau_and_balance(bureau, bureau_balance, dd)\n",
+    "bureau_agg = process_bureau_and_balance(bureau, bureau_balance, xd)\n",
     "\n",
-    "prev_agg = process_previous_applications(prev, dd)\n",
-    "pos_agg = pos_cash(pc_balance, dd)\n",
-    "ins_agg = installments_payments(payments, dd)\n",
-    "cc_agg = credit_card_balance(cc_balance, dd)\n",
+    "prev_agg = process_previous_applications(prev, xd)\n",
+    "pos_agg = pos_cash(pc_balance, xd)\n",
+    "ins_agg = installments_payments(payments, xd)\n",
+    "cc_agg = credit_card_balance(cc_balance, xd)\n",
     "\n",
     "unified_feat = unified_feat.join(bureau_agg, how='left', on='SK_ID_CURR') \\\n",
     "    .join(prev_agg, how='left', on='SK_ID_CURR') \\\n",
@@ -348,7 +356,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 11,
    "id": "packed-rescue",
    "metadata": {},
    "outputs": [
@@ -356,8 +364,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 5.53 s, sys: 280 ms, total: 5.81 s\n",
-      "Wall time: 4.83 s\n"
+      "CPU times: user 5.72 s, sys: 315 ms, total: 6.04 s\n",
+      "Wall time: 5.39 s\n"
      ]
     }
    ],
@@ -370,9 +378,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python [conda env:rapids]",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "conda-env-rapids-py"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -384,7 +392,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.8"
+   "version": "3.8.10"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This PR:
- Initializes a 14 GB RMM pool (to succeed on GPUs with only 16 GB of memory)
- Adds a few explicit `del`s to ensure memory stays below 14 GB (avoiding the need to use managed memory on a 16 GB GPU)
- Updates the import `dd` to `xd`, as `dd` is canonically for `dask.dataframe`

With the default allocator pool (on my machine with a V100 32 GB GPU):
- Reading stage takes 1 second (previously 3 seconds)
- ETL stage takes 5 seconds (15 seconds)
- Writing takes 1 second (2 seconds)

Quick comment, cuDF is apparently reading some columns as strings that pandas is reading as categorical. This segment of code in the cuDF section would fail if there were any categorical columns.

```python
from sklearn.preprocessing import LabelEncoder
# label encode cats
label_encode_dict = {}

categorical = unified_feat.select_dtypes(include=pd.CategoricalDtype).columns 
for column in categorical:
    label_encode_dict[column] = LabelEncoder()
    unified_feat[column] =  label_encode_dict[column].fit_transform(unified_feat[column])
    unified_feat[column] = unified_feat[column].astype('int64')
```

We can cast with `astype` and use cuML's LabelEncoder if desirable. Happy to discuss more.

